### PR TITLE
fix: add mode in theme color palette and remove menu selection type

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,15 +64,11 @@ void main() {
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return MechanixTheme(
-      data: MechanixThemeData(
-        mechanixVariant: MechanixVariant.blue,
-        themeMode: ThemeMode.system,
-        useMaterial3: true,
-      ),
-      child: MaterialApp(
-        title: 'My Mechanix App',
-        home: HomePage(),
+    return MaterialApp(
+      title: 'My Mechanix App',
+      home: MechanixTheme(
+        data: MechanixThemeData(mechanixVariant: MechanixVariant.coral),
+        child: HomePage(),
       ),
     );
   }

--- a/flutter/widgets/example/lib/pages/popup_menu_page.dart
+++ b/flutter/widgets/example/lib/pages/popup_menu_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:widgets/mechanix.dart';
-import 'package:widgets/widgets/menu/constants/menu_selection_type.dart';
 import 'package:widgets/widgets/menu/constants/menu_transitions.dart';
 import 'package:widgets/widgets/menu/models/mechanix_menu_item.dart';
 
@@ -57,7 +56,6 @@ class _PopupMenuPageState extends State<PopupMenuPage> {
                 MechanixMenu.builder(
                   menuController: _menuController,
                   animationType: MenuTransitions.slideDown,
-                  selectionType: MenuSelection.single,
                   isMenuButtonRequired: false,
                   itemCount: 4,
                   itemBuilder: (context, index) {

--- a/flutter/widgets/example/lib/pages/theme_colors_page.dart
+++ b/flutter/widgets/example/lib/pages/theme_colors_page.dart
@@ -41,10 +41,14 @@ class MechanixThemeColorsPage extends StatelessWidget with WatchItMixin {
     final mechanixVariant =
         watchPropertyValue((ThemeToggle t) => t.mechanixVariant);
 
+    final mechanixThemeMode =
+        watchPropertyValue((ThemeToggle t) => t.themeMode);
+
     final colorSetting =
         ColorSetting(accentColor: mechanixVariant?.color ?? Colors.blue);
 
-    final ThemeColors themeColors = colorSetting.getThemeColor();
+    final ThemeColors themeColors =
+        colorSetting.getThemeColor(themeMode: mechanixThemeMode);
 
     final accents = [
       {"accent 0": themeColors.accent_0},
@@ -58,8 +62,6 @@ class MechanixThemeColorsPage extends StatelessWidget with WatchItMixin {
       {"accent 800": themeColors.accent_800},
       {"accent 900": themeColors.accent_900},
       {"accent 1000": themeColors.accent_1000},
-      {"accent 1100": themeColors.accent_1100},
-      {"accent 1200": themeColors.accent_1200},
     ];
 
     final backgrounds = [
@@ -74,8 +76,6 @@ class MechanixThemeColorsPage extends StatelessWidget with WatchItMixin {
       {"background 800": themeColors.background_800},
       {"background 900": themeColors.background_900},
       {"background 1000": themeColors.background_1000},
-      {"background 1100": themeColors.background_1100},
-      {"background 1200": themeColors.background_1200},
     ];
 
     final foregrounds = [
@@ -90,8 +90,6 @@ class MechanixThemeColorsPage extends StatelessWidget with WatchItMixin {
       {"foreground 800": themeColors.foreground_800},
       {"foreground 900": themeColors.foreground_900},
       {"foreground 1000": themeColors.foreground_1000},
-      {"foreground 1100": themeColors.foreground_1100},
-      {"foreground 1200": themeColors.foreground_1200},
     ];
 
     return Scaffold(


### PR DESCRIPTION
## Fixes

- Updated example to correctly apply color palette based on the active theme mode
- Removed `selectionType` from Mechanix menu
- Updated `MechanixTheme` implementation in README