### PR TITLE
feat(icon-button) : implement icon button component

### DIFF
--- a/example/lib/features/components/icon_button_preview.dart
+++ b/example/lib/features/components/icon_button_preview.dart
@@ -45,7 +45,7 @@ class IconButtonPreview extends StatelessWidget {
             borderRadius: BorderRadius.circular(12),
           ),
           child: Icon(
-            Icons.radio_button_checked_rounded,
+            Icons.info_outline_rounded,
             size: 28,
             color: colorScheme.primary,
           ),
@@ -150,18 +150,6 @@ class IconButtonPreview extends StatelessWidget {
       runSpacing: 12,
       crossAxisAlignment: WrapCrossAlignment.center,
       children: [
-        // MechanixIconButton(
-        //   variant: item.variant,
-        //   type: IconButtonType.square,
-        //   icon: Icons.add_rounded,
-        //   onPressed: () {},
-        // ),
-        // MechanixIconButton(
-        //   variant: item.variant,
-        //   type: IconButtonType.rounded,
-        //   icon: Icons.favorite_rounded,
-        //   onPressed: () {},
-        // ),
         MechanixIconButton(
           variant: item.variant,
           type: IconButtonType.square,
@@ -319,7 +307,10 @@ class IconButtonPreview extends StatelessWidget {
                     ),
                     Column(
                       children: [
-                        Text('Disabled', style: theme.textTheme.bodySmall),
+                        Text(
+                          'Filled Disabled',
+                          style: theme.textTheme.bodySmall,
+                        ),
                         const SizedBox(height: 6),
                         const MechanixIconButton.filled(
                           icon: Icons.block_rounded,
@@ -335,6 +326,32 @@ class IconButtonPreview extends StatelessWidget {
                         ),
                         const SizedBox(height: 6),
                         const MechanixIconButton.outline(
+                          icon: Icons.block_rounded,
+                          onPressed: null,
+                        ),
+                      ],
+                    ),
+                    Column(
+                      children: [
+                        Text(
+                          'Tonal Disabled',
+                          style: theme.textTheme.bodySmall,
+                        ),
+                        const SizedBox(height: 6),
+                        const MechanixIconButton.tonal(
+                          icon: Icons.block_rounded,
+                          onPressed: null,
+                        ),
+                      ],
+                    ),
+                    Column(
+                      children: [
+                        Text(
+                          'Standard Disabled',
+                          style: theme.textTheme.bodySmall,
+                        ),
+                        const SizedBox(height: 6),
+                        const MechanixIconButton.standard(
                           icon: Icons.block_rounded,
                           onPressed: null,
                         ),

--- a/example/lib/features/components/icon_button_preview.dart
+++ b/example/lib/features/components/icon_button_preview.dart
@@ -438,9 +438,9 @@ class IconButtonPreview extends StatelessWidget {
         codeName: 'xLarge',
       ),
       _SizeItem(
-        size: IconButtonSize.twoXLarge,
-        name: '2X Large (twoXLarge)',
-        codeName: 'twoXLarge',
+        size: IconButtonSize.xxLarge,
+        name: '2X Large (xxLarge)',
+        codeName: 'xxLarge',
       ),
     ];
 

--- a/example/lib/features/components/icon_button_preview.dart
+++ b/example/lib/features/components/icon_button_preview.dart
@@ -1,0 +1,648 @@
+import 'package:flutter/material.dart';
+import 'package:widgets/widgets.dart';
+
+/// A polished design-system documentation page demonstrating all variants,
+/// shape types, sizes, interactive states, and touch targets of [MechanixIconButton].
+class IconButtonPreview extends StatelessWidget {
+  const IconButtonPreview({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // 1. Page Header
+        _buildPageHeader(context),
+        const SizedBox(height: 24),
+
+        // 2. Variants & Shape Types
+        _buildVariantsAndTypesSection(context),
+        const SizedBox(height: 32),
+
+        // 3. Button States (Enabled, Disabled, Custom Severities)
+        _buildStatesSection(context),
+        const SizedBox(height: 32),
+
+        // 4. Icon Button Sizes Scale
+        _buildSizesSection(context),
+        const SizedBox(height: 32),
+      ],
+    );
+  }
+
+  Widget _buildPageHeader(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final textTheme = theme.textTheme;
+
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Container(
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: colorScheme.primary.withValues(alpha: 0.12),
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Icon(
+            Icons.radio_button_checked_rounded,
+            size: 28,
+            color: colorScheme.primary,
+          ),
+        ),
+        const SizedBox(width: 16),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Icon Buttons',
+                style: textTheme.headlineMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+                overflow: TextOverflow.ellipsis,
+              ),
+              const SizedBox(height: 4),
+              Text(
+                'Mechanix Icon Button Variants, Shapes, Sizing Scale (32px to 136px), States & 48px Touch Targets',
+                style: textTheme.bodyMedium?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  // --- SECTION 2: VARIANTS & TYPES ---
+  Widget _buildVariantsAndTypesSection(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    final items = [
+      _VariantTypeItem(
+        title: 'Filled - Square & Rounded',
+        description:
+            'Primary solid background with square or rounded pill corners',
+        variant: IconButtonVariant.filled,
+      ),
+      _VariantTypeItem(
+        title: 'Tonal - Square & Rounded',
+        description: 'Secondary background with square or rounded pill corners',
+        variant: IconButtonVariant.tonal,
+      ),
+      _VariantTypeItem(
+        title: 'Outline - Square & Rounded',
+        description: 'Outlined border with surface variant background',
+        variant: IconButtonVariant.outline,
+      ),
+      _VariantTypeItem(
+        title: 'Standard - Square & Rounded',
+        description:
+            'Transparent background with state layer on hover/press/focus',
+        variant: IconButtonVariant.standard,
+      ),
+    ];
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Variants & Shape Types',
+          style: theme.textTheme.titleMedium?.copyWith(
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        const SizedBox(height: 12),
+        Card(
+          elevation: 0,
+          color: colorScheme.surfaceContainer,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+            side: BorderSide(color: colorScheme.outlineVariant),
+          ),
+          child: Column(
+            children: [
+              for (int i = 0; i < items.length; i++) ...[
+                if (i > 0)
+                  Divider(
+                    height: 1,
+                    color: colorScheme.outlineVariant.withValues(alpha: 0.6),
+                  ),
+                _buildVariantTypeRow(context, items[i]),
+              ],
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildVariantTypeRow(BuildContext context, _VariantTypeItem item) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final isDesktop = MediaQuery.sizeOf(context).width >= 900;
+
+    final samples = Wrap(
+      spacing: 16,
+      runSpacing: 12,
+      crossAxisAlignment: WrapCrossAlignment.center,
+      children: [
+        // MechanixIconButton(
+        //   variant: item.variant,
+        //   type: IconButtonType.square,
+        //   icon: Icons.add_rounded,
+        //   onPressed: () {},
+        // ),
+        // MechanixIconButton(
+        //   variant: item.variant,
+        //   type: IconButtonType.rounded,
+        //   icon: Icons.favorite_rounded,
+        //   onPressed: () {},
+        // ),
+        MechanixIconButton(
+          variant: item.variant,
+          type: IconButtonType.square,
+          icon: Icons.settings_rounded,
+          onPressed: () {},
+        ),
+        MechanixIconButton(
+          variant: item.variant,
+          type: IconButtonType.rounded,
+          icon: Icons.share_rounded,
+          onPressed: () {},
+        ),
+      ],
+    );
+
+    if (isDesktop) {
+      return Padding(
+        padding: const EdgeInsets.all(20),
+        child: Row(
+          children: [
+            SizedBox(
+              width: 240,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    item.title,
+                    style: theme.textTheme.labelLarge?.copyWith(
+                      fontWeight: FontWeight.w600,
+                      color: colorScheme.onSurface,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    item.description,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 24),
+            Expanded(child: samples),
+          ],
+        ),
+      );
+    }
+
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            item.title,
+            style: theme.textTheme.labelMedium?.copyWith(
+              fontWeight: FontWeight.w600,
+              color: colorScheme.primary,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            item.description,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: 12),
+          samples,
+        ],
+      ),
+    );
+  }
+
+  // --- SECTION 3: BUTTON STATES ---
+  Widget _buildStatesSection(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Interactive States & Custom Styling',
+          style: theme.textTheme.titleMedium?.copyWith(
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        const SizedBox(height: 12),
+        Card(
+          elevation: 0,
+          color: colorScheme.surfaceContainer,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+            side: BorderSide(color: colorScheme.outlineVariant),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(20),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Interactive & Disabled States',
+                  style: theme.textTheme.labelLarge?.copyWith(
+                    fontWeight: FontWeight.w600,
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                ),
+                const SizedBox(height: 12),
+                Wrap(
+                  spacing: 20,
+                  runSpacing: 16,
+                  crossAxisAlignment: WrapCrossAlignment.center,
+                  children: [
+                    Column(
+                      children: [
+                        Text('Filled', style: theme.textTheme.bodySmall),
+                        const SizedBox(height: 6),
+                        MechanixIconButton.filled(
+                          icon: Icons.check_circle_outline_rounded,
+                          onPressed: () {},
+                        ),
+                      ],
+                    ),
+                    Column(
+                      children: [
+                        Text('Tonal', style: theme.textTheme.bodySmall),
+                        const SizedBox(height: 6),
+                        MechanixIconButton.tonal(
+                          icon: Icons.edit_rounded,
+                          onPressed: () {},
+                        ),
+                      ],
+                    ),
+                    Column(
+                      children: [
+                        Text('Outline', style: theme.textTheme.bodySmall),
+                        const SizedBox(height: 6),
+                        MechanixIconButton.outline(
+                          icon: Icons.refresh_rounded,
+                          onPressed: () {},
+                        ),
+                      ],
+                    ),
+                    Column(
+                      children: [
+                        Text('Standard', style: theme.textTheme.bodySmall),
+                        const SizedBox(height: 6),
+                        MechanixIconButton.standard(
+                          icon: Icons.more_vert_rounded,
+                          onPressed: () {},
+                        ),
+                      ],
+                    ),
+                    Column(
+                      children: [
+                        Text('Disabled', style: theme.textTheme.bodySmall),
+                        const SizedBox(height: 6),
+                        const MechanixIconButton.filled(
+                          icon: Icons.block_rounded,
+                          onPressed: null,
+                        ),
+                      ],
+                    ),
+                    Column(
+                      children: [
+                        Text(
+                          'Outline Disabled',
+                          style: theme.textTheme.bodySmall,
+                        ),
+                        const SizedBox(height: 6),
+                        const MechanixIconButton.outline(
+                          icon: Icons.block_rounded,
+                          onPressed: null,
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 24),
+                Divider(
+                  height: 1,
+                  color: colorScheme.outlineVariant.withValues(alpha: 0.6),
+                ),
+                const SizedBox(height: 24),
+                Text(
+                  'Color Overrides & Status Severities',
+                  style: theme.textTheme.labelLarge?.copyWith(
+                    fontWeight: FontWeight.w600,
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                ),
+                const SizedBox(height: 12),
+                Wrap(
+                  spacing: 16,
+                  runSpacing: 12,
+                  crossAxisAlignment: WrapCrossAlignment.center,
+                  children: [
+                    MechanixIconButton(
+                      icon: Icons.delete_forever_rounded,
+                      backgroundColor: colorScheme.error,
+                      foregroundColor: colorScheme.onError,
+                      onPressed: () {},
+                    ),
+                    MechanixIconButton(
+                      icon: Icons.check_rounded,
+                      backgroundColor: const Color(0xFF2E7D32),
+                      foregroundColor: Colors.white,
+                      onPressed: () {},
+                    ),
+                    MechanixIconButton.outline(
+                      icon: Icons.warning_amber_rounded,
+                      borderColor: const Color(0xFFED6C02),
+                      foregroundColor: const Color(0xFFED6C02),
+                      onPressed: () {},
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  // --- SECTION 4: BUTTON SIZES ---
+  Widget _buildSizesSection(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    final sizes = [
+      _SizeItem(
+        size: IconButtonSize.xSmall,
+        name: 'Extra Small (xSmall)',
+        codeName: 'xSmall',
+      ),
+      _SizeItem(
+        size: IconButtonSize.small,
+        name: 'Small (small)',
+        codeName: 'small',
+      ),
+      _SizeItem(
+        size: IconButtonSize.medium,
+        name: 'Medium (medium)',
+        codeName: 'medium',
+      ),
+      _SizeItem(
+        size: IconButtonSize.large,
+        name: 'Large (large)',
+        codeName: 'large',
+      ),
+      _SizeItem(
+        size: IconButtonSize.xLarge,
+        name: 'Extra Large (xLarge)',
+        codeName: 'xLarge',
+      ),
+      _SizeItem(
+        size: IconButtonSize.twoXLarge,
+        name: '2X Large (twoXLarge)',
+        codeName: 'twoXLarge',
+      ),
+    ];
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Icon Button Scale & Sizes (xSmall to 2xl)',
+          style: theme.textTheme.titleMedium?.copyWith(
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        const SizedBox(height: 12),
+        Card(
+          elevation: 0,
+          color: colorScheme.surfaceContainer,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+            side: BorderSide(color: colorScheme.outlineVariant),
+          ),
+          child: Column(
+            children: [
+              for (int i = 0; i < sizes.length; i++) ...[
+                if (i > 0)
+                  Divider(
+                    height: 1,
+                    color: colorScheme.outlineVariant.withValues(alpha: 0.6),
+                  ),
+                _buildSizeRow(context, sizes[i]),
+              ],
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSizeRow(BuildContext context, _SizeItem item) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final spec = item.size.spec(context);
+    final isDesktop = MediaQuery.sizeOf(context).width >= 900;
+
+    final metadataContent = [
+      _buildMetaRow(
+        'Dimension',
+        '${spec.dimension.toStringAsFixed(0)}x${spec.dimension.toStringAsFixed(0)}px',
+        colorScheme,
+      ),
+      const SizedBox(height: 2),
+      _buildMetaRow('Icon Size', '${spec.iconSize}px', colorScheme),
+      const SizedBox(height: 2),
+      _buildMetaRow(
+        'Tap Target',
+        spec.minTapTargetSize > 0
+            ? '${spec.minTapTargetSize.toStringAsFixed(0)}x${spec.minTapTargetSize.toStringAsFixed(0)}px'
+            : 'Standard',
+        colorScheme,
+      ),
+    ];
+
+    final buttonSamples = Wrap(
+      spacing: 16,
+      runSpacing: 12,
+      crossAxisAlignment: WrapCrossAlignment.center,
+      children: [
+        MechanixIconButton(
+          size: item.size,
+          icon: Icons.rocket_launch_rounded,
+          onPressed: () {},
+        ),
+        MechanixIconButton.tonal(
+          size: item.size,
+          icon: Icons.rocket_launch_rounded,
+          onPressed: () {},
+        ),
+        MechanixIconButton.outline(
+          size: item.size,
+          icon: Icons.rocket_launch_rounded,
+          onPressed: () {},
+        ),
+        MechanixIconButton.standard(
+          size: item.size,
+          icon: Icons.rocket_launch_rounded,
+          onPressed: () {},
+        ),
+      ],
+    );
+
+    if (isDesktop) {
+      return Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            SizedBox(
+              width: 180,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    item.name,
+                    style: theme.textTheme.labelLarge?.copyWith(
+                      fontWeight: FontWeight.w600,
+                      color: colorScheme.onSurface,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    item.codeName,
+                    style: TextStyle(
+                      fontSize: 10,
+                      fontFamily: 'monospace',
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 16),
+            SizedBox(
+              width: 160,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: metadataContent,
+              ),
+            ),
+            const SizedBox(width: 24),
+            Expanded(child: buttonSamples),
+          ],
+        ),
+      );
+    }
+
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            item.name,
+            style: theme.textTheme.labelMedium?.copyWith(
+              fontWeight: FontWeight.w600,
+              color: colorScheme.primary,
+            ),
+          ),
+          const SizedBox(height: 2),
+          Text(
+            item.codeName,
+            style: TextStyle(
+              fontSize: 11,
+              fontFamily: 'monospace',
+              color: colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: 12),
+          buttonSamples,
+          const SizedBox(height: 12),
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(10),
+            decoration: BoxDecoration(
+              color: colorScheme.surfaceContainerLow,
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(
+                color: colorScheme.outlineVariant.withValues(alpha: 0.5),
+              ),
+            ),
+            child: Column(children: metadataContent),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMetaRow(String label, String value, ColorScheme colorScheme) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text(
+          label,
+          style: TextStyle(fontSize: 11, color: colorScheme.onSurfaceVariant),
+        ),
+        const SizedBox(width: 8),
+        Text(
+          value,
+          style: TextStyle(
+            fontSize: 11,
+            fontWeight: FontWeight.w600,
+            fontFamily: 'monospace',
+            color: colorScheme.onSurface,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _VariantTypeItem {
+  final String title;
+  final String description;
+  final IconButtonVariant variant;
+
+  const _VariantTypeItem({
+    required this.title,
+    required this.description,
+    required this.variant,
+  });
+}
+
+class _SizeItem {
+  final IconButtonSize size;
+  final String name;
+  final String codeName;
+
+  const _SizeItem({
+    required this.size,
+    required this.name,
+    required this.codeName,
+  });
+}

--- a/example/lib/layout/app_shell.dart
+++ b/example/lib/layout/app_shell.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:widgets/widgets.dart';
 
 import '../features/components/button_preview.dart';
+import '../features/components/icon_button_preview.dart';
 import '../features/theme/theme_preview.dart';
 import '../features/typography/typography_preview.dart';
 import 'app_sidebar.dart';
@@ -107,6 +108,8 @@ class _AppShellState extends State<AppShell> {
         return 'Theme Overview';
       case 'buttons':
         return 'Buttons';
+      case 'icon_buttons':
+        return 'Icon Buttons';
       case 'inputs':
         return 'Inputs';
       case 'cards':
@@ -134,6 +137,9 @@ class _MainContent extends StatelessWidget {
         break;
       case 'buttons':
         content = const ButtonPreview();
+        break;
+      case 'icon_buttons':
+        content = const IconButtonPreview();
         break;
       case 'theme':
         content = const ThemePreview();

--- a/example/lib/layout/app_sidebar.dart
+++ b/example/lib/layout/app_sidebar.dart
@@ -111,6 +111,12 @@ class AppSidebar extends StatelessWidget {
                 title: 'Buttons',
                 icon: Icons.smart_button_outlined,
               ),
+              _buildNavItem(
+                context,
+                id: 'icon_buttons',
+                title: 'Icon Buttons',
+                icon: Icons.info_outline_rounded,
+              ),
             ],
           ),
         ),

--- a/widgets/lib/src/components/button/button_size.dart
+++ b/widgets/lib/src/components/button/button_size.dart
@@ -51,7 +51,7 @@ class ButtonSizeConfig {
           labelTextStyle: textTheme.titleMedium!,
           padding: const EdgeInsets.symmetric(horizontal: 24),
           iconLabelGap: 8,
-          minTapTargetSize: 0,
+          minTapTargetSize: 48,
         );
 
       case ButtonSize.large:

--- a/widgets/lib/src/components/button/button_style.dart
+++ b/widgets/lib/src/components/button/button_style.dart
@@ -124,6 +124,17 @@ abstract class ButtonStyleResolver {
 
     // 5. State-aware border side
     final sideProperty = WidgetStateProperty.resolveWith<BorderSide?>((states) {
+      if (states.contains(WidgetState.focused) && showFocusIndicator) {
+        final focColor =
+            customFocusBorderColor ??
+            theme?.focusBorderColor ??
+            (isOutline
+                ? (baseBorderColor ?? scheme.outline)
+                : scheme.secondaryFixedDim);
+        final focWidth = customBorderWidth ?? theme?.borderWidth ?? 3.0;
+        return BorderSide(color: focColor, width: focWidth);
+      }
+
       if (isOutline) {
         final w = baseBorderWidth ?? 1.0;
         if (states.contains(WidgetState.disabled)) {
@@ -132,26 +143,10 @@ abstract class ButtonStyleResolver {
             width: w,
           );
         }
-        if (states.contains(WidgetState.focused) && showFocusIndicator) {
-          final focColor =
-              customFocusBorderColor ??
-              theme?.focusBorderColor ??
-              baseBorderColor ??
-              scheme.outline;
-          final focWidth = customBorderWidth ?? theme?.borderWidth ?? 3.0;
-          return BorderSide(color: focColor, width: focWidth);
-        }
         return BorderSide(color: baseBorderColor ?? scheme.outline, width: w);
       } else {
         if (baseBorderColor != null) {
           final w = baseBorderWidth ?? 0.0;
-          if (states.contains(WidgetState.focused) &&
-              showFocusIndicator &&
-              (customFocusBorderColor != null ||
-                  theme?.focusBorderColor != null)) {
-            final focColor = customFocusBorderColor ?? theme?.focusBorderColor!;
-            return BorderSide(color: focColor!, width: w);
-          }
           return BorderSide(color: baseBorderColor, width: w);
         }
         return null;

--- a/widgets/lib/src/components/icon_button/icon_button.dart
+++ b/widgets/lib/src/components/icon_button/icon_button.dart
@@ -121,33 +121,6 @@ class MechanixIconButton extends StatelessWidget {
     this.theme,
   }) : variant = IconButtonVariant.outline;
 
-  /// Alias constructor for an Outline [MechanixIconButton].
-  const MechanixIconButton.outlined({
-    super.key,
-    required this.onPressed,
-    required this.icon,
-    this.onLongPress,
-    this.type = IconButtonType.square,
-    this.size = IconButtonSize.medium,
-    this.showFocusIndicator = true,
-    this.focusNode,
-    this.autofocus = false,
-    this.duration = const Duration(milliseconds: 200),
-    this.curve = const Cubic(0.2, 0.0, 0.0, 1.0),
-    this.backgroundColor,
-    this.hoverColor,
-    this.pressedColor,
-    this.disabledColor,
-    this.foregroundColor,
-    this.hoverForegroundColor,
-    this.pressedForegroundColor,
-    this.disabledForegroundColor,
-    this.borderColor,
-    this.borderWidth,
-    this.focusBorderColor,
-    this.theme,
-  }) : variant = IconButtonVariant.outline;
-
   /// Factory constructor for a Standard [MechanixIconButton].
   const MechanixIconButton.standard({
     super.key,

--- a/widgets/lib/src/components/icon_button/icon_button.dart
+++ b/widgets/lib/src/components/icon_button/icon_button.dart
@@ -1,0 +1,353 @@
+import 'package:flutter/material.dart';
+
+import 'icon_button_enums.dart';
+import 'icon_button_size.dart';
+import 'icon_button_style.dart';
+import 'icon_button_theme.dart';
+
+export 'icon_button_enums.dart';
+export 'icon_button_size.dart';
+export 'icon_button_style.dart';
+export 'icon_button_theme.dart';
+
+/// A highly customizable Icon Button component following the
+/// Mechanix design system specifications.
+class MechanixIconButton extends StatelessWidget {
+  const MechanixIconButton({
+    super.key,
+    required this.onPressed,
+    required this.icon,
+    this.onLongPress,
+    this.type = IconButtonType.square,
+    this.variant = IconButtonVariant.filled,
+    this.size = IconButtonSize.medium,
+    this.showFocusIndicator = true,
+    this.focusNode,
+    this.autofocus = false,
+    this.duration = const Duration(milliseconds: 200),
+    this.curve = const Cubic(0.2, 0.0, 0.0, 1.0),
+    this.backgroundColor,
+    this.hoverColor,
+    this.pressedColor,
+    this.disabledColor,
+    this.foregroundColor,
+    this.hoverForegroundColor,
+    this.pressedForegroundColor,
+    this.disabledForegroundColor,
+    this.borderColor,
+    this.borderWidth,
+    this.focusBorderColor,
+    this.theme,
+  });
+
+  /// Factory constructor for a Filled [MechanixIconButton].
+  const MechanixIconButton.filled({
+    super.key,
+    required this.onPressed,
+    required this.icon,
+    this.onLongPress,
+    this.type = IconButtonType.square,
+    this.size = IconButtonSize.medium,
+    this.showFocusIndicator = true,
+    this.focusNode,
+    this.autofocus = false,
+    this.duration = const Duration(milliseconds: 200),
+    this.curve = const Cubic(0.2, 0.0, 0.0, 1.0),
+    this.backgroundColor,
+    this.hoverColor,
+    this.pressedColor,
+    this.disabledColor,
+    this.foregroundColor,
+    this.hoverForegroundColor,
+    this.pressedForegroundColor,
+    this.disabledForegroundColor,
+    this.borderColor,
+    this.borderWidth,
+    this.focusBorderColor,
+    this.theme,
+  }) : variant = IconButtonVariant.filled;
+
+  /// Factory constructor for a Tonal [MechanixIconButton].
+  const MechanixIconButton.tonal({
+    super.key,
+    required this.onPressed,
+    required this.icon,
+    this.onLongPress,
+    this.type = IconButtonType.square,
+    this.size = IconButtonSize.medium,
+    this.showFocusIndicator = true,
+    this.focusNode,
+    this.autofocus = false,
+    this.duration = const Duration(milliseconds: 200),
+    this.curve = const Cubic(0.2, 0.0, 0.0, 1.0),
+    this.backgroundColor,
+    this.hoverColor,
+    this.pressedColor,
+    this.disabledColor,
+    this.foregroundColor,
+    this.hoverForegroundColor,
+    this.pressedForegroundColor,
+    this.disabledForegroundColor,
+    this.borderColor,
+    this.borderWidth,
+    this.focusBorderColor,
+    this.theme,
+  }) : variant = IconButtonVariant.tonal;
+
+  /// Factory constructor for an Outline [MechanixIconButton].
+  const MechanixIconButton.outline({
+    super.key,
+    required this.onPressed,
+    required this.icon,
+    this.onLongPress,
+    this.type = IconButtonType.square,
+    this.size = IconButtonSize.medium,
+    this.showFocusIndicator = true,
+    this.focusNode,
+    this.autofocus = false,
+    this.duration = const Duration(milliseconds: 200),
+    this.curve = const Cubic(0.2, 0.0, 0.0, 1.0),
+    this.backgroundColor,
+    this.hoverColor,
+    this.pressedColor,
+    this.disabledColor,
+    this.foregroundColor,
+    this.hoverForegroundColor,
+    this.pressedForegroundColor,
+    this.disabledForegroundColor,
+    this.borderColor,
+    this.borderWidth,
+    this.focusBorderColor,
+    this.theme,
+  }) : variant = IconButtonVariant.outline;
+
+  /// Alias constructor for an Outline [MechanixIconButton].
+  const MechanixIconButton.outlined({
+    super.key,
+    required this.onPressed,
+    required this.icon,
+    this.onLongPress,
+    this.type = IconButtonType.square,
+    this.size = IconButtonSize.medium,
+    this.showFocusIndicator = true,
+    this.focusNode,
+    this.autofocus = false,
+    this.duration = const Duration(milliseconds: 200),
+    this.curve = const Cubic(0.2, 0.0, 0.0, 1.0),
+    this.backgroundColor,
+    this.hoverColor,
+    this.pressedColor,
+    this.disabledColor,
+    this.foregroundColor,
+    this.hoverForegroundColor,
+    this.pressedForegroundColor,
+    this.disabledForegroundColor,
+    this.borderColor,
+    this.borderWidth,
+    this.focusBorderColor,
+    this.theme,
+  }) : variant = IconButtonVariant.outline;
+
+  /// Factory constructor for a Standard [MechanixIconButton].
+  const MechanixIconButton.standard({
+    super.key,
+    required this.onPressed,
+    required this.icon,
+    this.onLongPress,
+    this.type = IconButtonType.square,
+    this.size = IconButtonSize.medium,
+    this.showFocusIndicator = true,
+    this.focusNode,
+    this.autofocus = false,
+    this.duration = const Duration(milliseconds: 200),
+    this.curve = const Cubic(0.2, 0.0, 0.0, 1.0),
+    this.backgroundColor,
+    this.hoverColor,
+    this.pressedColor,
+    this.disabledColor,
+    this.foregroundColor,
+    this.hoverForegroundColor,
+    this.pressedForegroundColor,
+    this.disabledForegroundColor,
+    this.borderColor,
+    this.borderWidth,
+    this.focusBorderColor,
+    this.theme,
+  }) : variant = IconButtonVariant.standard;
+
+  /// Callback when button is clicked. If null, button is disabled.
+  final VoidCallback? onPressed;
+
+  /// Callback when button is long pressed.
+  final VoidCallback? onLongPress;
+
+  /// Icon widget or IconData to display.
+  final dynamic icon;
+
+  /// Corner/shape style type ([IconButtonType.square], [rounded]).
+  final IconButtonType type;
+
+  /// Visual style variant ([IconButtonVariant.filled], [tonal], [outline], [standard]).
+  final IconButtonVariant variant;
+
+  /// Button scale size ([IconButtonSize.xSmall], [small], [medium], [large], [xLarge], [twoXLarge]).
+  final IconButtonSize size;
+
+  /// Controls whether focus border indicator outline is shown when focused.
+  final bool showFocusIndicator;
+
+  /// Optional FocusNode.
+  final FocusNode? focusNode;
+
+  /// Whether this button should auto focus on init.
+  final bool autofocus;
+
+  /// Hover/press/focus animation duration.
+  final Duration duration;
+
+  /// Hover/press/focus animation easing curve.
+  final Curve curve;
+
+  /// Background color overrides.
+  final Color? backgroundColor;
+  final Color? hoverColor;
+  final Color? pressedColor;
+  final Color? disabledColor;
+
+  /// Foreground / Icon color overrides.
+  final Color? foregroundColor;
+  final Color? hoverForegroundColor;
+  final Color? pressedForegroundColor;
+  final Color? disabledForegroundColor;
+
+  /// Border styling overrides.
+  final Color? borderColor;
+  final double? borderWidth;
+  final Color? focusBorderColor;
+
+  /// Custom theme override for this button instance.
+  final IconButtonThemeDataConfig? theme;
+
+  bool get isEnabled => onPressed != null || onLongPress != null;
+
+  @override
+  Widget build(BuildContext context) {
+    final mergedTheme = MechanixIconButtonTheme.of(context).merge(theme);
+    final sizeSpec = size.spec(context);
+
+    final buttonStyle = IconButtonStyleResolver.createButtonStyle(
+      context: context,
+      variant: variant,
+      type: type,
+      sizeSpec: sizeSpec,
+      theme: mergedTheme,
+      customBackgroundColor: backgroundColor,
+      customHoverColor: hoverColor,
+      customPressedColor: pressedColor,
+      customDisabledColor: disabledColor,
+      customForegroundColor: foregroundColor,
+      customHoverForegroundColor: hoverForegroundColor,
+      customPressedForegroundColor: pressedForegroundColor,
+      customDisabledForegroundColor: disabledForegroundColor,
+      customBorderColor: borderColor,
+      customBorderWidth: borderWidth,
+      customFocusBorderColor: focusBorderColor,
+      duration: duration,
+      curve: curve,
+      showFocusIndicator: showFocusIndicator,
+    );
+
+    final iconWidget = _buildIcon(mergedTheme, sizeSpec);
+
+    Widget buttonWidget;
+    switch (variant) {
+      case IconButtonVariant.filled:
+        buttonWidget = IconButton.filled(
+          onPressed: onPressed,
+          focusNode: focusNode,
+          autofocus: autofocus,
+          style: buttonStyle,
+          icon: iconWidget,
+        );
+        break;
+      case IconButtonVariant.tonal:
+        buttonWidget = IconButton.filledTonal(
+          onPressed: onPressed,
+          focusNode: focusNode,
+          autofocus: autofocus,
+          style: buttonStyle,
+          icon: iconWidget,
+        );
+        break;
+      case IconButtonVariant.outline:
+        buttonWidget = IconButton.outlined(
+          onPressed: onPressed,
+          focusNode: focusNode,
+          autofocus: autofocus,
+          style: buttonStyle,
+          icon: iconWidget,
+        );
+        break;
+      case IconButtonVariant.standard:
+        buttonWidget = IconButton(
+          onPressed: onPressed,
+          focusNode: focusNode,
+          autofocus: autofocus,
+          style: buttonStyle,
+          icon: iconWidget,
+        );
+        break;
+    }
+
+    if (onLongPress != null) {
+      buttonWidget = GestureDetector(
+        behavior: HitTestBehavior.translucent,
+        onLongPress: onLongPress,
+        child: buttonWidget,
+      );
+    }
+
+    buttonWidget = SizedBox(
+      width: sizeSpec.dimension,
+      height: sizeSpec.dimension,
+      child: buttonWidget,
+    );
+
+    if (sizeSpec.minTapTargetSize > 0) {
+      buttonWidget = GestureDetector(
+        behavior: HitTestBehavior.translucent,
+        onTap: onPressed,
+        onLongPress: onLongPress,
+        child: ConstrainedBox(
+          constraints: BoxConstraints(
+            minWidth: sizeSpec.minTapTargetSize,
+            minHeight: sizeSpec.minTapTargetSize,
+          ),
+          child: Center(
+            widthFactor: 1.0,
+            heightFactor: 1.0,
+            child: buttonWidget,
+          ),
+        ),
+      );
+    }
+
+    return buttonWidget;
+  }
+
+  Widget _buildIcon(
+    IconButtonThemeDataConfig theme,
+    IconButtonSizeConfig sizeSpec,
+  ) {
+    final targetIconSize = theme.iconSize ?? sizeSpec.iconSize;
+    if (icon is Widget) {
+      return IconTheme.merge(
+        data: IconThemeData(size: targetIconSize),
+        child: icon as Widget,
+      );
+    } else if (icon is IconData) {
+      return Icon(icon as IconData, size: targetIconSize);
+    }
+    return const SizedBox.shrink();
+  }
+}

--- a/widgets/lib/src/components/icon_button/icon_button_enums.dart
+++ b/widgets/lib/src/components/icon_button/icon_button_enums.dart
@@ -1,0 +1,40 @@
+import '../button/button_enums.dart';
+
+/// Defines the visual variant of the [MechanixIconButton].
+enum IconButtonVariant {
+  /// Filled background button style with primary color.
+  filled,
+
+  /// Tonal background button style with secondary color.
+  tonal,
+
+  /// Outlined border button style with surface variant background.
+  outline,
+
+  /// Standard icon button style with transparent background.
+  standard,
+}
+
+/// Defines the pre-set sizing scale of the [MechanixIconButton].
+enum IconButtonSize {
+  /// 32x32 button dimension, 20px icon size, min tap target 48x48.
+  xSmall,
+
+  /// 40x40 button dimension, 24px icon size, min tap target 48x48.
+  small,
+
+  /// 56x56 button dimension, 24px icon size.
+  medium,
+
+  /// 72x72 button dimension, 30.86px icon size.
+  large,
+
+  /// 96x96 button dimension, 32px icon size.
+  xLarge,
+
+  /// 136x136 button dimension, 40px icon size.
+  twoXLarge,
+}
+
+/// Alias for [ButtonType] to define corner/shape style.
+typedef IconButtonType = ButtonType;

--- a/widgets/lib/src/components/icon_button/icon_button_enums.dart
+++ b/widgets/lib/src/components/icon_button/icon_button_enums.dart
@@ -33,7 +33,7 @@ enum IconButtonSize {
   xLarge,
 
   /// 136x136 button dimension, 40px icon size.
-  twoXLarge,
+  xxLarge,
 }
 
 /// Alias for [ButtonType] to define corner/shape style.

--- a/widgets/lib/src/components/icon_button/icon_button_size.dart
+++ b/widgets/lib/src/components/icon_button/icon_button_size.dart
@@ -51,7 +51,7 @@ class IconButtonSizeConfig {
           minTapTargetSize: 0,
         );
 
-      case IconButtonSize.twoXLarge:
+      case IconButtonSize.xxLarge:
         return const IconButtonSizeConfig(
           dimension: 136,
           iconSize: 40,

--- a/widgets/lib/src/components/icon_button/icon_button_size.dart
+++ b/widgets/lib/src/components/icon_button/icon_button_size.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'icon_button_enums.dart';
+
+/// Resolved specifications (dimension, icon size, min tap target)
+/// corresponding to a given [IconButtonSize].
+class IconButtonSizeConfig {
+  final double dimension;
+  final double iconSize;
+  final double minTapTargetSize;
+
+  const IconButtonSizeConfig({
+    required this.dimension,
+    required this.iconSize,
+    required this.minTapTargetSize,
+  });
+
+  factory IconButtonSizeConfig.of(BuildContext context, IconButtonSize size) {
+    switch (size) {
+      case IconButtonSize.xSmall:
+        return const IconButtonSizeConfig(
+          dimension: 32,
+          iconSize: 20,
+          minTapTargetSize: 48,
+        );
+
+      case IconButtonSize.small:
+        return const IconButtonSizeConfig(
+          dimension: 40,
+          iconSize: 24,
+          minTapTargetSize: 48,
+        );
+
+      case IconButtonSize.medium:
+        return const IconButtonSizeConfig(
+          dimension: 56,
+          iconSize: 24,
+          minTapTargetSize: 0,
+        );
+
+      case IconButtonSize.large:
+        return const IconButtonSizeConfig(
+          dimension: 72,
+          iconSize: 30.86,
+          minTapTargetSize: 0,
+        );
+
+      case IconButtonSize.xLarge:
+        return const IconButtonSizeConfig(
+          dimension: 96,
+          iconSize: 32,
+          minTapTargetSize: 0,
+        );
+
+      case IconButtonSize.twoXLarge:
+        return const IconButtonSizeConfig(
+          dimension: 136,
+          iconSize: 40,
+          minTapTargetSize: 0,
+        );
+    }
+  }
+}
+
+/// Extension on [IconButtonSize] for convenient access to its specifications.
+extension MechanixIconButtonSizeExtension on IconButtonSize {
+  IconButtonSizeConfig spec(BuildContext context) {
+    return IconButtonSizeConfig.of(context, this);
+  }
+}

--- a/widgets/lib/src/components/icon_button/icon_button_style.dart
+++ b/widgets/lib/src/components/icon_button/icon_button_style.dart
@@ -32,7 +32,6 @@ abstract class IconButtonStyleResolver {
     final shapeTheme = context.shape;
 
     // 1. Shape resolution:
-    // Custom theme.borderRadius -> ShapeTheme.full (rounded) -> ShapeTheme.none (square)
     final borderRadius =
         theme?.borderRadius ??
         switch (type) {
@@ -74,21 +73,36 @@ abstract class IconButtonStyleResolver {
         break;
     }
 
-    final baseBg = customBackgroundColor ?? theme?.backgroundColor ?? defaultBg;
-    final baseFg = customForegroundColor ?? theme?.foregroundColor ?? defaultFg;
-    final baseBorderColor =
-        customBorderColor ?? theme?.borderColor ?? defaultBorderColor;
-    final baseBorderWidth =
-        customBorderWidth ?? theme?.borderWidth ?? defaultBorderWidth;
+    final baseBg = customBackgroundColor ?? defaultBg;
+    final baseFg = customForegroundColor ?? defaultFg;
+    final baseBorderColor = customBorderColor ?? defaultBorderColor;
+    final baseBorderWidth = customBorderWidth ?? defaultBorderWidth;
 
     // 3. State-aware background resolution
     final backgroundColorProperty = WidgetStateProperty.resolveWith<Color?>((
       states,
     ) {
+      if (states.contains(WidgetState.disabled) &&
+          customDisabledColor != null) {
+        return customDisabledColor;
+      }
+      if (states.contains(WidgetState.pressed) && customPressedColor != null) {
+        return customPressedColor;
+      }
+      if (states.contains(WidgetState.hovered) && customHoverColor != null) {
+        return customHoverColor;
+      }
+      if (customBackgroundColor != null) {
+        return customBackgroundColor;
+      }
+
+      // Resolve from theme WidgetStateProperty if provided
+      if (theme?.backgroundColor != null) {
+        final themeColor = theme!.backgroundColor!.resolve(states);
+        if (themeColor != null) return themeColor;
+      }
+
       if (states.contains(WidgetState.disabled)) {
-        if (customDisabledColor != null || theme?.disabledColor != null) {
-          return customDisabledColor ?? theme?.disabledColor;
-        }
         return switch (variant) {
           IconButtonVariant.filled ||
           IconButtonVariant.tonal => scheme.onSurface.withValues(alpha: 0.10),
@@ -97,51 +111,20 @@ abstract class IconButtonStyleResolver {
         };
       }
 
-      if (states.contains(WidgetState.pressed)) {
-        if (customPressedColor != null || theme?.pressedColor != null) {
-          return customPressedColor ?? theme?.pressedColor;
-        }
+      if (states.contains(WidgetState.pressed) ||
+          states.contains(WidgetState.hovered) ||
+          states.contains(WidgetState.focused)) {
         final stateLayerColor = switch (variant) {
           IconButtonVariant.filled => scheme.onPrimary,
           IconButtonVariant.tonal => scheme.onSecondaryContainer,
           IconButtonVariant.outline ||
           IconButtonVariant.standard => scheme.onSurfaceVariant,
         };
+        final opacity = states.contains(WidgetState.pressed) ? 0.12 : 0.08;
         return _applyStateLayer(
           baseColor: baseBg,
           stateLayerColor: stateLayerColor,
-          opacity: 0.12,
-        );
-      }
-
-      if (states.contains(WidgetState.hovered)) {
-        if (customHoverColor != null || theme?.hoverColor != null) {
-          return customHoverColor ?? theme?.hoverColor;
-        }
-        final stateLayerColor = switch (variant) {
-          IconButtonVariant.filled => scheme.onPrimary,
-          IconButtonVariant.tonal => scheme.onSecondaryContainer,
-          IconButtonVariant.outline ||
-          IconButtonVariant.standard => scheme.onSurfaceVariant,
-        };
-        return _applyStateLayer(
-          baseColor: baseBg,
-          stateLayerColor: stateLayerColor,
-          opacity: 0.08,
-        );
-      }
-
-      if (states.contains(WidgetState.focused)) {
-        final stateLayerColor = switch (variant) {
-          IconButtonVariant.filled => scheme.onPrimary,
-          IconButtonVariant.tonal => scheme.onSecondaryContainer,
-          IconButtonVariant.outline ||
-          IconButtonVariant.standard => scheme.onSurfaceVariant,
-        };
-        return _applyStateLayer(
-          baseColor: baseBg,
-          stateLayerColor: stateLayerColor,
-          opacity: 0.08,
+          opacity: opacity,
         );
       }
 
@@ -152,36 +135,49 @@ abstract class IconButtonStyleResolver {
     final foregroundColorProperty = WidgetStateProperty.resolveWith<Color?>((
       states,
     ) {
+      if (states.contains(WidgetState.disabled) &&
+          customDisabledForegroundColor != null) {
+        return customDisabledForegroundColor;
+      }
+      if (states.contains(WidgetState.pressed) &&
+          customPressedForegroundColor != null) {
+        return customPressedForegroundColor;
+      }
+      if (states.contains(WidgetState.hovered) &&
+          customHoverForegroundColor != null) {
+        return customHoverForegroundColor;
+      }
+      if (customForegroundColor != null) {
+        return customForegroundColor;
+      }
+
+      // Resolve from theme WidgetStateProperty if provided
+      if (theme?.foregroundColor != null) {
+        final themeFg = theme!.foregroundColor!.resolve(states);
+        if (themeFg != null) return themeFg;
+      }
+
       if (states.contains(WidgetState.disabled)) {
-        return customDisabledForegroundColor ??
-            theme?.disabledForegroundColor ??
-            scheme.onSurface.withValues(alpha: 0.38);
-      }
-      if (states.contains(WidgetState.pressed)) {
-        return customPressedForegroundColor ??
-            theme?.pressedForegroundColor ??
-            baseFg;
-      }
-      if (states.contains(WidgetState.hovered)) {
-        return customHoverForegroundColor ??
-            theme?.hoverForegroundColor ??
-            baseFg;
+        return scheme.onSurface.withValues(alpha: 0.38);
       }
       return baseFg;
     });
 
     // 5. State-aware border side resolution
     final sideProperty = WidgetStateProperty.resolveWith<BorderSide?>((states) {
+      // Resolve from theme WidgetStateProperty if provided
+      if (theme?.side != null) {
+        final themeSide = theme!.side!.resolve(states);
+        if (themeSide != null) return themeSide;
+      }
+
       final defaultFocusColor = switch (variant) {
         IconButtonVariant.standard => scheme.secondary,
         _ => scheme.secondaryFixedDim,
       };
 
-      final focusBorderColor =
-          customFocusBorderColor ??
-          theme?.focusBorderColor ??
-          defaultFocusColor;
-      final focusWidth = customBorderWidth ?? theme?.borderWidth ?? 3.0;
+      final focusBorderColor = customFocusBorderColor ?? defaultFocusColor;
+      final focusWidth = customBorderWidth ?? 3.0;
 
       if (states.contains(WidgetState.focused) && showFocusIndicator) {
         return BorderSide(color: focusBorderColor, width: focusWidth);

--- a/widgets/lib/src/components/icon_button/icon_button_style.dart
+++ b/widgets/lib/src/components/icon_button/icon_button_style.dart
@@ -1,0 +1,263 @@
+import 'package:flutter/material.dart';
+import 'package:widgets/widgets.dart';
+
+/// Helper for constructing Material [ButtonStyle] configurations for [MechanixIconButton].
+abstract class IconButtonStyleResolver {
+  const IconButtonStyleResolver();
+
+  /// Creates a Material [ButtonStyle] for [MechanixIconButton] using variant,
+  /// type, sizing spec, theme data, and custom color overrides.
+  static ButtonStyle createButtonStyle({
+    required BuildContext context,
+    required IconButtonVariant variant,
+    required IconButtonType type,
+    required IconButtonSizeConfig sizeSpec,
+    IconButtonThemeDataConfig? theme,
+    Color? customBackgroundColor,
+    Color? customHoverColor,
+    Color? customPressedColor,
+    Color? customDisabledColor,
+    Color? customForegroundColor,
+    Color? customHoverForegroundColor,
+    Color? customPressedForegroundColor,
+    Color? customDisabledForegroundColor,
+    Color? customBorderColor,
+    double? customBorderWidth,
+    Color? customFocusBorderColor,
+    Duration? duration,
+    Curve? curve,
+    bool showFocusIndicator = true,
+  }) {
+    final scheme = context.colorScheme;
+    final shapeTheme = context.shape;
+
+    // 1. Shape resolution:
+    // Custom theme.borderRadius -> ShapeTheme.full (rounded) -> ShapeTheme.none (square)
+    final borderRadius =
+        theme?.borderRadius ??
+        switch (type) {
+          IconButtonType.square => shapeTheme.none,
+          IconButtonType.rounded => shapeTheme.full,
+        };
+    final shape = RoundedRectangleBorder(borderRadius: borderRadius);
+
+    // 2. Default color resolution per variant:
+    late final Color defaultBg;
+    late final Color defaultFg;
+    late final Color? defaultBorderColor;
+    late final double defaultBorderWidth;
+
+    switch (variant) {
+      case IconButtonVariant.filled:
+        defaultBg = scheme.primary;
+        defaultFg = scheme.onSurface;
+        defaultBorderColor = scheme.secondaryFixedDim;
+        defaultBorderWidth = 1.0;
+        break;
+      case IconButtonVariant.tonal:
+        defaultBg = scheme.secondary;
+        defaultFg = scheme.onSecondaryFixed;
+        defaultBorderColor = null;
+        defaultBorderWidth = 0.0;
+        break;
+      case IconButtonVariant.outline:
+        defaultBg = scheme.secondary;
+        defaultFg = scheme.onSecondaryFixed;
+        defaultBorderColor = scheme.outline;
+        defaultBorderWidth = 2.0;
+        break;
+      case IconButtonVariant.standard:
+        defaultBg = Colors.transparent;
+        defaultFg = scheme.onSecondaryFixed;
+        defaultBorderColor = null;
+        defaultBorderWidth = 0.0;
+        break;
+    }
+
+    final baseBg = customBackgroundColor ?? theme?.backgroundColor ?? defaultBg;
+    final baseFg = customForegroundColor ?? theme?.foregroundColor ?? defaultFg;
+    final baseBorderColor =
+        customBorderColor ?? theme?.borderColor ?? defaultBorderColor;
+    final baseBorderWidth =
+        customBorderWidth ?? theme?.borderWidth ?? defaultBorderWidth;
+
+    // 3. State-aware background resolution
+    final backgroundColorProperty = WidgetStateProperty.resolveWith<Color?>((
+      states,
+    ) {
+      if (states.contains(WidgetState.disabled)) {
+        if (customDisabledColor != null || theme?.disabledColor != null) {
+          return customDisabledColor ?? theme?.disabledColor;
+        }
+        return switch (variant) {
+          IconButtonVariant.filled ||
+          IconButtonVariant.tonal => scheme.onSurface.withValues(alpha: 0.10),
+          IconButtonVariant.outline => Colors.transparent,
+          IconButtonVariant.standard => Colors.transparent,
+        };
+      }
+
+      if (states.contains(WidgetState.pressed)) {
+        if (customPressedColor != null || theme?.pressedColor != null) {
+          return customPressedColor ?? theme?.pressedColor;
+        }
+        final stateLayerColor = switch (variant) {
+          IconButtonVariant.filled => scheme.onPrimary,
+          IconButtonVariant.tonal => scheme.onSecondaryContainer,
+          IconButtonVariant.outline ||
+          IconButtonVariant.standard => scheme.onSurfaceVariant,
+        };
+        return _applyStateLayer(
+          baseColor: baseBg,
+          stateLayerColor: stateLayerColor,
+          opacity: 0.12,
+        );
+      }
+
+      if (states.contains(WidgetState.hovered)) {
+        if (customHoverColor != null || theme?.hoverColor != null) {
+          return customHoverColor ?? theme?.hoverColor;
+        }
+        final stateLayerColor = switch (variant) {
+          IconButtonVariant.filled => scheme.onPrimary,
+          IconButtonVariant.tonal => scheme.onSecondaryContainer,
+          IconButtonVariant.outline ||
+          IconButtonVariant.standard => scheme.onSurfaceVariant,
+        };
+        return _applyStateLayer(
+          baseColor: baseBg,
+          stateLayerColor: stateLayerColor,
+          opacity: 0.08,
+        );
+      }
+
+      if (states.contains(WidgetState.focused)) {
+        final stateLayerColor = switch (variant) {
+          IconButtonVariant.filled => scheme.onPrimary,
+          IconButtonVariant.tonal => scheme.onSecondaryContainer,
+          IconButtonVariant.outline ||
+          IconButtonVariant.standard => scheme.onSurfaceVariant,
+        };
+        return _applyStateLayer(
+          baseColor: baseBg,
+          stateLayerColor: stateLayerColor,
+          opacity: 0.08,
+        );
+      }
+
+      return baseBg;
+    });
+
+    // 4. State-aware foreground resolution
+    final foregroundColorProperty = WidgetStateProperty.resolveWith<Color?>((
+      states,
+    ) {
+      if (states.contains(WidgetState.disabled)) {
+        return customDisabledForegroundColor ??
+            theme?.disabledForegroundColor ??
+            scheme.onSurface.withValues(alpha: 0.38);
+      }
+      if (states.contains(WidgetState.pressed)) {
+        return customPressedForegroundColor ??
+            theme?.pressedForegroundColor ??
+            baseFg;
+      }
+      if (states.contains(WidgetState.hovered)) {
+        return customHoverForegroundColor ??
+            theme?.hoverForegroundColor ??
+            baseFg;
+      }
+      return baseFg;
+    });
+
+    // 5. State-aware border side resolution
+    final sideProperty = WidgetStateProperty.resolveWith<BorderSide?>((states) {
+      final defaultFocusColor = switch (variant) {
+        IconButtonVariant.standard => scheme.secondary,
+        _ => scheme.secondaryFixedDim,
+      };
+
+      final focusBorderColor =
+          customFocusBorderColor ??
+          theme?.focusBorderColor ??
+          defaultFocusColor;
+      final focusWidth = customBorderWidth ?? theme?.borderWidth ?? 3.0;
+
+      if (states.contains(WidgetState.focused) && showFocusIndicator) {
+        return BorderSide(color: focusBorderColor, width: focusWidth);
+      }
+
+      if (states.contains(WidgetState.disabled)) {
+        return switch (variant) {
+          IconButtonVariant.filled => BorderSide(
+            color: scheme.secondary.withValues(alpha: 0.10),
+            width: baseBorderWidth,
+          ),
+          IconButtonVariant.outline => BorderSide(
+            color: (baseBorderColor ?? scheme.outline).withValues(alpha: 0.38),
+            width: baseBorderWidth,
+          ),
+          IconButtonVariant.tonal || IconButtonVariant.standard =>
+            baseBorderColor != null
+                ? BorderSide(
+                    color: baseBorderColor.withValues(alpha: 0.38),
+                    width: baseBorderWidth,
+                  )
+                : null,
+        };
+      }
+
+      if (baseBorderColor != null) {
+        return BorderSide(color: baseBorderColor, width: baseBorderWidth);
+      }
+
+      return null;
+    });
+
+    // 6. Native tap target sizing
+    final tapTargetSize = sizeSpec.minTapTargetSize > 0
+        ? MaterialTapTargetSize.padded
+        : MaterialTapTargetSize.shrinkWrap;
+
+    return ButtonStyle(
+      overlayColor: WidgetStateProperty.all(Colors.transparent),
+      backgroundColor: backgroundColorProperty,
+      foregroundColor: foregroundColorProperty,
+      iconColor: foregroundColorProperty,
+      side: sideProperty,
+      shape: WidgetStateProperty.all(shape),
+      padding: WidgetStateProperty.all(EdgeInsets.zero),
+      minimumSize: WidgetStateProperty.all(
+        Size(sizeSpec.dimension, sizeSpec.dimension),
+      ),
+      fixedSize: WidgetStateProperty.all(
+        Size(sizeSpec.dimension, sizeSpec.dimension),
+      ),
+      alignment: Alignment.center,
+      elevation: WidgetStateProperty.all(theme?.elevation ?? 0.0),
+      iconSize: WidgetStateProperty.all(theme?.iconSize ?? sizeSpec.iconSize),
+      animationDuration: duration ?? const Duration(milliseconds: 200),
+      tapTargetSize: tapTargetSize,
+      mouseCursor: WidgetStateProperty.resolveWith<MouseCursor>((states) {
+        if (states.contains(WidgetState.disabled)) {
+          return SystemMouseCursors.basic;
+        }
+        return SystemMouseCursors.click;
+      }),
+    );
+  }
+}
+
+Color _applyStateLayer({
+  required Color baseColor,
+  required Color stateLayerColor,
+  required double opacity,
+}) {
+  if (baseColor == Colors.transparent) {
+    return stateLayerColor.withValues(alpha: opacity);
+  }
+  return Color.alphaBlend(
+    stateLayerColor.withValues(alpha: opacity),
+    baseColor,
+  );
+}

--- a/widgets/lib/src/components/icon_button/icon_button_theme.dart
+++ b/widgets/lib/src/components/icon_button/icon_button_theme.dart
@@ -1,39 +1,32 @@
+import 'dart:ui' show lerpDouble;
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
+/// Scoped Theme extension config for [MechanixIconButton].
 @immutable
 class IconButtonThemeDataConfig
     extends ThemeExtension<IconButtonThemeDataConfig>
     with Diagnosticable {
   const IconButtonThemeDataConfig({
     this.backgroundColor,
-    this.hoverColor,
-    this.pressedColor,
-    this.disabledColor,
     this.foregroundColor,
-    this.hoverForegroundColor,
-    this.pressedForegroundColor,
-    this.disabledForegroundColor,
-    this.focusBorderColor,
-    this.borderColor,
-    this.borderWidth,
+    this.side,
     this.iconSize,
     this.borderRadius,
     this.elevation,
     this.focusIndicatorWidth,
   });
 
-  final Color? backgroundColor;
-  final Color? hoverColor;
-  final Color? pressedColor;
-  final Color? disabledColor;
-  final Color? foregroundColor;
-  final Color? hoverForegroundColor;
-  final Color? pressedForegroundColor;
-  final Color? disabledForegroundColor;
-  final Color? focusBorderColor;
-  final Color? borderColor;
-  final double? borderWidth;
+  /// State-aware background color property.
+  final WidgetStateProperty<Color?>? backgroundColor;
+
+  /// State-aware foreground/icon color property.
+  final WidgetStateProperty<Color?>? foregroundColor;
+
+  /// State-aware border side property.
+  final WidgetStateProperty<BorderSide?>? side;
+
   final double? iconSize;
   final BorderRadius? borderRadius;
   final double? elevation;
@@ -41,17 +34,9 @@ class IconButtonThemeDataConfig
 
   @override
   IconButtonThemeDataConfig copyWith({
-    Color? backgroundColor,
-    Color? hoverColor,
-    Color? pressedColor,
-    Color? disabledColor,
-    Color? foregroundColor,
-    Color? hoverForegroundColor,
-    Color? pressedForegroundColor,
-    Color? disabledForegroundColor,
-    Color? focusBorderColor,
-    Color? borderColor,
-    double? borderWidth,
+    WidgetStateProperty<Color?>? backgroundColor,
+    WidgetStateProperty<Color?>? foregroundColor,
+    WidgetStateProperty<BorderSide?>? side,
     double? iconSize,
     BorderRadius? borderRadius,
     double? elevation,
@@ -59,18 +44,8 @@ class IconButtonThemeDataConfig
   }) {
     return IconButtonThemeDataConfig(
       backgroundColor: backgroundColor ?? this.backgroundColor,
-      hoverColor: hoverColor ?? this.hoverColor,
-      pressedColor: pressedColor ?? this.pressedColor,
-      disabledColor: disabledColor ?? this.disabledColor,
       foregroundColor: foregroundColor ?? this.foregroundColor,
-      hoverForegroundColor: hoverForegroundColor ?? this.hoverForegroundColor,
-      pressedForegroundColor:
-          pressedForegroundColor ?? this.pressedForegroundColor,
-      disabledForegroundColor:
-          disabledForegroundColor ?? this.disabledForegroundColor,
-      focusBorderColor: focusBorderColor ?? this.focusBorderColor,
-      borderColor: borderColor ?? this.borderColor,
-      borderWidth: borderWidth ?? this.borderWidth,
+      side: side ?? this.side,
       iconSize: iconSize ?? this.iconSize,
       borderRadius: borderRadius ?? this.borderRadius,
       elevation: elevation ?? this.elevation,
@@ -80,18 +55,11 @@ class IconButtonThemeDataConfig
 
   IconButtonThemeDataConfig merge(IconButtonThemeDataConfig? other) {
     if (other == null) return this;
+
     return copyWith(
       backgroundColor: other.backgroundColor,
-      hoverColor: other.hoverColor,
-      pressedColor: other.pressedColor,
-      disabledColor: other.disabledColor,
       foregroundColor: other.foregroundColor,
-      hoverForegroundColor: other.hoverForegroundColor,
-      pressedForegroundColor: other.pressedForegroundColor,
-      disabledForegroundColor: other.disabledForegroundColor,
-      focusBorderColor: other.focusBorderColor,
-      borderColor: other.borderColor,
-      borderWidth: other.borderWidth,
+      side: other.side,
       iconSize: other.iconSize,
       borderRadius: other.borderRadius,
       elevation: other.elevation,
@@ -105,30 +73,31 @@ class IconButtonThemeDataConfig
     double t,
   ) {
     if (other is! IconButtonThemeDataConfig) return this;
+
     return IconButtonThemeDataConfig(
-      backgroundColor: Color.lerp(backgroundColor, other.backgroundColor, t),
-      hoverColor: Color.lerp(hoverColor, other.hoverColor, t),
-      pressedColor: Color.lerp(pressedColor, other.pressedColor, t),
-      disabledColor: Color.lerp(disabledColor, other.disabledColor, t),
-      foregroundColor: Color.lerp(foregroundColor, other.foregroundColor, t),
-      hoverForegroundColor: Color.lerp(
-        hoverForegroundColor,
-        other.hoverForegroundColor,
+      backgroundColor: WidgetStateProperty.lerp<Color?>(
+        backgroundColor,
+        other.backgroundColor,
         t,
+        Color.lerp,
       ),
-      pressedForegroundColor: Color.lerp(
-        pressedForegroundColor,
-        other.pressedForegroundColor,
+      foregroundColor: WidgetStateProperty.lerp<Color?>(
+        foregroundColor,
+        other.foregroundColor,
         t,
+        Color.lerp,
       ),
-      disabledForegroundColor: Color.lerp(
-        disabledForegroundColor,
-        other.disabledForegroundColor,
+      side: WidgetStateProperty.lerp<BorderSide?>(side, other.side, t, (
+        a,
+        b,
         t,
-      ),
-      focusBorderColor: Color.lerp(focusBorderColor, other.focusBorderColor, t),
-      borderColor: Color.lerp(borderColor, other.borderColor, t),
-      borderWidth: lerpDouble(borderWidth, other.borderWidth, t),
+      ) {
+        if (a == null && b == null) {
+          return null;
+        }
+
+        return BorderSide.lerp(a ?? BorderSide.none, b ?? BorderSide.none, t);
+      }),
       iconSize: lerpDouble(iconSize, other.iconSize, t),
       borderRadius: BorderRadius.lerp(borderRadius, other.borderRadius, t),
       elevation: lerpDouble(elevation, other.elevation, t),
@@ -140,31 +109,13 @@ class IconButtonThemeDataConfig
     );
   }
 
-  double? lerpDouble(double? a, double? b, double t) {
-    if (a == null && b == null) return null;
-    return (a ?? 0.0) + ((b ?? 0.0) - (a ?? 0.0)) * t;
-  }
-
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
+
     properties.add(DiagnosticsProperty('backgroundColor', backgroundColor));
-    properties.add(DiagnosticsProperty('hoverColor', hoverColor));
-    properties.add(DiagnosticsProperty('pressedColor', pressedColor));
-    properties.add(DiagnosticsProperty('disabledColor', disabledColor));
     properties.add(DiagnosticsProperty('foregroundColor', foregroundColor));
-    properties.add(
-      DiagnosticsProperty('hoverForegroundColor', hoverForegroundColor),
-    );
-    properties.add(
-      DiagnosticsProperty('pressedForegroundColor', pressedForegroundColor),
-    );
-    properties.add(
-      DiagnosticsProperty('disabledForegroundColor', disabledForegroundColor),
-    );
-    properties.add(DiagnosticsProperty('focusBorderColor', focusBorderColor));
-    properties.add(DiagnosticsProperty('borderColor', borderColor));
-    properties.add(DiagnosticsProperty('borderWidth', borderWidth));
+    properties.add(DiagnosticsProperty('side', side));
     properties.add(DiagnosticsProperty('iconSize', iconSize));
     properties.add(DiagnosticsProperty('borderRadius', borderRadius));
     properties.add(DiagnosticsProperty('elevation', elevation));
@@ -176,18 +127,11 @@ class IconButtonThemeDataConfig
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
+
     return other is IconButtonThemeDataConfig &&
         backgroundColor == other.backgroundColor &&
-        hoverColor == other.hoverColor &&
-        pressedColor == other.pressedColor &&
-        disabledColor == other.disabledColor &&
         foregroundColor == other.foregroundColor &&
-        hoverForegroundColor == other.hoverForegroundColor &&
-        pressedForegroundColor == other.pressedForegroundColor &&
-        disabledForegroundColor == other.disabledForegroundColor &&
-        focusBorderColor == other.focusBorderColor &&
-        borderColor == other.borderColor &&
-        borderWidth == other.borderWidth &&
+        side == other.side &&
         iconSize == other.iconSize &&
         borderRadius == other.borderRadius &&
         elevation == other.elevation &&
@@ -196,23 +140,15 @@ class IconButtonThemeDataConfig
 
   @override
   int get hashCode {
-    return Object.hashAll([
+    return Object.hash(
       backgroundColor,
-      hoverColor,
-      pressedColor,
-      disabledColor,
       foregroundColor,
-      hoverForegroundColor,
-      pressedForegroundColor,
-      disabledForegroundColor,
-      focusBorderColor,
-      borderColor,
-      borderWidth,
+      side,
       iconSize,
       borderRadius,
       elevation,
       focusIndicatorWidth,
-    ]);
+    );
   }
 }
 
@@ -228,6 +164,7 @@ class MechanixIconButtonTheme extends InheritedTheme {
   static IconButtonThemeDataConfig of(BuildContext context) {
     final theme = context
         .dependOnInheritedWidgetOfExactType<MechanixIconButtonTheme>();
+
     return theme?.data ??
         Theme.of(context).extension<IconButtonThemeDataConfig>() ??
         const IconButtonThemeDataConfig();

--- a/widgets/lib/src/components/icon_button/icon_button_theme.dart
+++ b/widgets/lib/src/components/icon_button/icon_button_theme.dart
@@ -1,0 +1,245 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+@immutable
+class IconButtonThemeDataConfig
+    extends ThemeExtension<IconButtonThemeDataConfig>
+    with Diagnosticable {
+  const IconButtonThemeDataConfig({
+    this.backgroundColor,
+    this.hoverColor,
+    this.pressedColor,
+    this.disabledColor,
+    this.foregroundColor,
+    this.hoverForegroundColor,
+    this.pressedForegroundColor,
+    this.disabledForegroundColor,
+    this.focusBorderColor,
+    this.borderColor,
+    this.borderWidth,
+    this.iconSize,
+    this.borderRadius,
+    this.elevation,
+    this.focusIndicatorWidth,
+  });
+
+  final Color? backgroundColor;
+  final Color? hoverColor;
+  final Color? pressedColor;
+  final Color? disabledColor;
+  final Color? foregroundColor;
+  final Color? hoverForegroundColor;
+  final Color? pressedForegroundColor;
+  final Color? disabledForegroundColor;
+  final Color? focusBorderColor;
+  final Color? borderColor;
+  final double? borderWidth;
+  final double? iconSize;
+  final BorderRadius? borderRadius;
+  final double? elevation;
+  final double? focusIndicatorWidth;
+
+  @override
+  IconButtonThemeDataConfig copyWith({
+    Color? backgroundColor,
+    Color? hoverColor,
+    Color? pressedColor,
+    Color? disabledColor,
+    Color? foregroundColor,
+    Color? hoverForegroundColor,
+    Color? pressedForegroundColor,
+    Color? disabledForegroundColor,
+    Color? focusBorderColor,
+    Color? borderColor,
+    double? borderWidth,
+    double? iconSize,
+    BorderRadius? borderRadius,
+    double? elevation,
+    double? focusIndicatorWidth,
+  }) {
+    return IconButtonThemeDataConfig(
+      backgroundColor: backgroundColor ?? this.backgroundColor,
+      hoverColor: hoverColor ?? this.hoverColor,
+      pressedColor: pressedColor ?? this.pressedColor,
+      disabledColor: disabledColor ?? this.disabledColor,
+      foregroundColor: foregroundColor ?? this.foregroundColor,
+      hoverForegroundColor: hoverForegroundColor ?? this.hoverForegroundColor,
+      pressedForegroundColor:
+          pressedForegroundColor ?? this.pressedForegroundColor,
+      disabledForegroundColor:
+          disabledForegroundColor ?? this.disabledForegroundColor,
+      focusBorderColor: focusBorderColor ?? this.focusBorderColor,
+      borderColor: borderColor ?? this.borderColor,
+      borderWidth: borderWidth ?? this.borderWidth,
+      iconSize: iconSize ?? this.iconSize,
+      borderRadius: borderRadius ?? this.borderRadius,
+      elevation: elevation ?? this.elevation,
+      focusIndicatorWidth: focusIndicatorWidth ?? this.focusIndicatorWidth,
+    );
+  }
+
+  IconButtonThemeDataConfig merge(IconButtonThemeDataConfig? other) {
+    if (other == null) return this;
+    return copyWith(
+      backgroundColor: other.backgroundColor,
+      hoverColor: other.hoverColor,
+      pressedColor: other.pressedColor,
+      disabledColor: other.disabledColor,
+      foregroundColor: other.foregroundColor,
+      hoverForegroundColor: other.hoverForegroundColor,
+      pressedForegroundColor: other.pressedForegroundColor,
+      disabledForegroundColor: other.disabledForegroundColor,
+      focusBorderColor: other.focusBorderColor,
+      borderColor: other.borderColor,
+      borderWidth: other.borderWidth,
+      iconSize: other.iconSize,
+      borderRadius: other.borderRadius,
+      elevation: other.elevation,
+      focusIndicatorWidth: other.focusIndicatorWidth,
+    );
+  }
+
+  @override
+  IconButtonThemeDataConfig lerp(
+    ThemeExtension<IconButtonThemeDataConfig>? other,
+    double t,
+  ) {
+    if (other is! IconButtonThemeDataConfig) return this;
+    return IconButtonThemeDataConfig(
+      backgroundColor: Color.lerp(backgroundColor, other.backgroundColor, t),
+      hoverColor: Color.lerp(hoverColor, other.hoverColor, t),
+      pressedColor: Color.lerp(pressedColor, other.pressedColor, t),
+      disabledColor: Color.lerp(disabledColor, other.disabledColor, t),
+      foregroundColor: Color.lerp(foregroundColor, other.foregroundColor, t),
+      hoverForegroundColor: Color.lerp(
+        hoverForegroundColor,
+        other.hoverForegroundColor,
+        t,
+      ),
+      pressedForegroundColor: Color.lerp(
+        pressedForegroundColor,
+        other.pressedForegroundColor,
+        t,
+      ),
+      disabledForegroundColor: Color.lerp(
+        disabledForegroundColor,
+        other.disabledForegroundColor,
+        t,
+      ),
+      focusBorderColor: Color.lerp(focusBorderColor, other.focusBorderColor, t),
+      borderColor: Color.lerp(borderColor, other.borderColor, t),
+      borderWidth: lerpDouble(borderWidth, other.borderWidth, t),
+      iconSize: lerpDouble(iconSize, other.iconSize, t),
+      borderRadius: BorderRadius.lerp(borderRadius, other.borderRadius, t),
+      elevation: lerpDouble(elevation, other.elevation, t),
+      focusIndicatorWidth: lerpDouble(
+        focusIndicatorWidth,
+        other.focusIndicatorWidth,
+        t,
+      ),
+    );
+  }
+
+  double? lerpDouble(double? a, double? b, double t) {
+    if (a == null && b == null) return null;
+    return (a ?? 0.0) + ((b ?? 0.0) - (a ?? 0.0)) * t;
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty('backgroundColor', backgroundColor));
+    properties.add(DiagnosticsProperty('hoverColor', hoverColor));
+    properties.add(DiagnosticsProperty('pressedColor', pressedColor));
+    properties.add(DiagnosticsProperty('disabledColor', disabledColor));
+    properties.add(DiagnosticsProperty('foregroundColor', foregroundColor));
+    properties.add(
+      DiagnosticsProperty('hoverForegroundColor', hoverForegroundColor),
+    );
+    properties.add(
+      DiagnosticsProperty('pressedForegroundColor', pressedForegroundColor),
+    );
+    properties.add(
+      DiagnosticsProperty('disabledForegroundColor', disabledForegroundColor),
+    );
+    properties.add(DiagnosticsProperty('focusBorderColor', focusBorderColor));
+    properties.add(DiagnosticsProperty('borderColor', borderColor));
+    properties.add(DiagnosticsProperty('borderWidth', borderWidth));
+    properties.add(DiagnosticsProperty('iconSize', iconSize));
+    properties.add(DiagnosticsProperty('borderRadius', borderRadius));
+    properties.add(DiagnosticsProperty('elevation', elevation));
+    properties.add(
+      DiagnosticsProperty('focusIndicatorWidth', focusIndicatorWidth),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is IconButtonThemeDataConfig &&
+        backgroundColor == other.backgroundColor &&
+        hoverColor == other.hoverColor &&
+        pressedColor == other.pressedColor &&
+        disabledColor == other.disabledColor &&
+        foregroundColor == other.foregroundColor &&
+        hoverForegroundColor == other.hoverForegroundColor &&
+        pressedForegroundColor == other.pressedForegroundColor &&
+        disabledForegroundColor == other.disabledForegroundColor &&
+        focusBorderColor == other.focusBorderColor &&
+        borderColor == other.borderColor &&
+        borderWidth == other.borderWidth &&
+        iconSize == other.iconSize &&
+        borderRadius == other.borderRadius &&
+        elevation == other.elevation &&
+        focusIndicatorWidth == other.focusIndicatorWidth;
+  }
+
+  @override
+  int get hashCode {
+    return Object.hashAll([
+      backgroundColor,
+      hoverColor,
+      pressedColor,
+      disabledColor,
+      foregroundColor,
+      hoverForegroundColor,
+      pressedForegroundColor,
+      disabledForegroundColor,
+      focusBorderColor,
+      borderColor,
+      borderWidth,
+      iconSize,
+      borderRadius,
+      elevation,
+      focusIndicatorWidth,
+    ]);
+  }
+}
+
+class MechanixIconButtonTheme extends InheritedTheme {
+  const MechanixIconButtonTheme({
+    super.key,
+    required this.data,
+    required super.child,
+  });
+
+  final IconButtonThemeDataConfig data;
+
+  static IconButtonThemeDataConfig of(BuildContext context) {
+    final theme = context
+        .dependOnInheritedWidgetOfExactType<MechanixIconButtonTheme>();
+    return theme?.data ??
+        Theme.of(context).extension<IconButtonThemeDataConfig>() ??
+        const IconButtonThemeDataConfig();
+  }
+
+  @override
+  Widget wrap(BuildContext context, Widget child) {
+    return MechanixIconButtonTheme(data: data, child: child);
+  }
+
+  @override
+  bool updateShouldNotify(MechanixIconButtonTheme oldWidget) {
+    return data != oldWidget.data;
+  }
+}

--- a/widgets/lib/src/theme/theme.dart
+++ b/widgets/lib/src/theme/theme.dart
@@ -65,6 +65,59 @@ abstract class MechanixTheme extends StatefulWidget {
       useMaterial3: true,
       colorScheme: colorScheme,
       textTheme: createTextTheme(textColor: colorScheme.onSurface),
+      extensions: const [ButtonThemeDataConfig(), IconButtonThemeDataConfig()],
+      iconButtonTheme: IconButtonThemeData(
+        style: ButtonStyle(
+          mouseCursor: WidgetStateProperty.resolveWith<MouseCursor>((states) {
+            if (states.contains(WidgetState.disabled)) {
+              return SystemMouseCursors.basic;
+            }
+            return SystemMouseCursors.click;
+          }),
+          overlayColor: WidgetStateProperty.all(Colors.transparent),
+          backgroundColor: WidgetStateProperty.resolveWith((states) {
+            if (states.contains(WidgetState.disabled)) {
+              return colorScheme.onSurface.withValues(alpha: 0.10);
+            }
+            if (states.contains(WidgetState.hovered) ||
+                states.contains(WidgetState.focused)) {
+              return Color.alphaBlend(
+                colorScheme.onPrimary.withValues(alpha: 0.08),
+                colorScheme.primary,
+              );
+            }
+            if (states.contains(WidgetState.pressed)) {
+              return Color.alphaBlend(
+                colorScheme.onPrimary.withValues(alpha: 0.12),
+                colorScheme.primary,
+              );
+            }
+            return colorScheme.primary;
+          }),
+          foregroundColor: WidgetStateProperty.resolveWith((states) {
+            if (states.contains(WidgetState.disabled)) {
+              return colorScheme.onSurface.withValues(alpha: 0.38);
+            }
+            return colorScheme.onPrimary;
+          }),
+          iconColor: WidgetStateProperty.resolveWith((states) {
+            if (states.contains(WidgetState.disabled)) {
+              return colorScheme.onSurface.withValues(alpha: 0.38);
+            }
+            return colorScheme.onPrimary;
+          }),
+          side: WidgetStateProperty.resolveWith((states) {
+            if (states.contains(WidgetState.focused)) {
+              return BorderSide(
+                color: colorScheme.secondary,
+                width: 3.0,
+              );
+            }
+            return null;
+          }),
+          animationDuration: const Duration(milliseconds: 200),
+        ),
+      ),
       filledButtonTheme: FilledButtonThemeData(
         style: ButtonStyle(
           mouseCursor: WidgetStateProperty.resolveWith<MouseCursor>((states) {

--- a/widgets/lib/widgets.dart
+++ b/widgets/lib/widgets.dart
@@ -22,3 +22,5 @@ export 'src/extensions/shape_extension.dart';
 export 'src/components/button/button_style.dart';
 export 'src/components/button/button_theme.dart';
 export 'src/components/button/button.dart';
+export 'src/components/icon_button/icon_button.dart';
+

--- a/widgets/test/components/icon_button/icon_button_test.dart
+++ b/widgets/test/components/icon_button/icon_button_test.dart
@@ -43,7 +43,7 @@ void main() {
         (IconButtonSize.medium, 56.0, 24.0),
         (IconButtonSize.large, 72.0, 30.86),
         (IconButtonSize.xLarge, 96.0, 32.0),
-        (IconButtonSize.twoXLarge, 136.0, 40.0),
+        (IconButtonSize.xxLarge, 136.0, 40.0),
       ];
 
       for (final spec in specs) {
@@ -189,28 +189,31 @@ void main() {
       expect(side?.width, equals(3.0));
     });
 
-    testWidgets('standard icon button has no border by default and 3px border only when focused', (
-      WidgetTester tester,
-    ) async {
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: MechanixIconButton.standard(
-              icon: Icons.star,
-              onPressed: () {},
+    testWidgets(
+      'standard icon button has no border by default and 3px border only when focused',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: MechanixIconButton.standard(
+                icon: Icons.star,
+                onPressed: () {},
+              ),
             ),
           ),
-        ),
-      );
+        );
 
-      final iconButton = tester.widget<IconButton>(find.byType(IconButton));
-      final defaultSide = iconButton.style?.side?.resolve({});
-      final focusedSide = iconButton.style?.side?.resolve({WidgetState.focused});
+        final iconButton = tester.widget<IconButton>(find.byType(IconButton));
+        final defaultSide = iconButton.style?.side?.resolve({});
+        final focusedSide = iconButton.style?.side?.resolve({
+          WidgetState.focused,
+        });
 
-      expect(defaultSide, isNull);
-      expect(focusedSide, isNotNull);
-      expect(focusedSide?.width, equals(3.0));
-    });
+        expect(defaultSide, isNull);
+        expect(focusedSide, isNotNull);
+        expect(focusedSide?.width, equals(3.0));
+      },
+    );
 
     testWidgets('verifies 48x48 min tap target for xSmall icon button', (
       WidgetTester tester,
@@ -270,6 +273,75 @@ void main() {
       // Verify the tap target constraints are at least 48x48
       expect(constrainedBox.constraints.minWidth, equals(48.0));
       expect(constrainedBox.constraints.minHeight, equals(48.0));
+    });
+
+    testWidgets('resolves state-aware colors from IconButtonThemeDataConfig WidgetStateProperty', (
+      WidgetTester tester,
+    ) async {
+      final themeConfig = IconButtonThemeDataConfig(
+        backgroundColor: WidgetStateProperty.resolveWith((states) {
+          if (states.contains(WidgetState.disabled)) return Colors.grey;
+          if (states.contains(WidgetState.hovered)) return Colors.blue;
+          return Colors.purple;
+        }),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: MechanixIconButtonTheme(
+              data: themeConfig,
+              child: MechanixIconButton.filled(
+                icon: Icons.star,
+                onPressed: () {},
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final iconButton = tester.widget<IconButton>(find.byType(IconButton));
+      final resolvedNormal = iconButton.style?.backgroundColor?.resolve({});
+      final resolvedDisabled = iconButton.style?.backgroundColor?.resolve({WidgetState.disabled});
+
+      expect(resolvedNormal, equals(Colors.purple));
+      expect(resolvedDisabled, equals(Colors.grey));
+    });
+
+    testWidgets('resolves state-aware side from IconButtonThemeDataConfig WidgetStateProperty', (
+      WidgetTester tester,
+    ) async {
+      final themeConfig = IconButtonThemeDataConfig(
+        side: WidgetStateProperty.resolveWith((states) {
+          if (states.contains(WidgetState.focused)) {
+            return const BorderSide(color: Colors.red, width: 4.0);
+          }
+          return const BorderSide(color: Colors.green, width: 2.0);
+        }),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: MechanixIconButtonTheme(
+              data: themeConfig,
+              child: MechanixIconButton.filled(
+                icon: Icons.star,
+                onPressed: () {},
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final iconButton = tester.widget<IconButton>(find.byType(IconButton));
+      final resolvedNormalSide = iconButton.style?.side?.resolve({});
+      final resolvedFocusedSide = iconButton.style?.side?.resolve({WidgetState.focused});
+
+      expect(resolvedNormalSide?.color, equals(Colors.green));
+      expect(resolvedNormalSide?.width, equals(2.0));
+      expect(resolvedFocusedSide?.color, equals(Colors.red));
+      expect(resolvedFocusedSide?.width, equals(4.0));
     });
   });
 }

--- a/widgets/test/components/icon_button/icon_button_test.dart
+++ b/widgets/test/components/icon_button/icon_button_test.dart
@@ -1,0 +1,275 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:widgets/widgets.dart';
+
+void main() {
+  group('MechanixIconButton Widget Tests', () {
+    testWidgets('renders all 4 icon button variants', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Column(
+              children: [
+                MechanixIconButton.filled(icon: Icons.add, onPressed: () {}),
+                MechanixIconButton.tonal(icon: Icons.edit, onPressed: () {}),
+                MechanixIconButton.outline(
+                  icon: Icons.delete,
+                  onPressed: () {},
+                ),
+                MechanixIconButton.standard(
+                  icon: Icons.share,
+                  onPressed: () {},
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.add), findsOneWidget);
+      expect(find.byIcon(Icons.edit), findsOneWidget);
+      expect(find.byIcon(Icons.delete), findsOneWidget);
+      expect(find.byIcon(Icons.share), findsOneWidget);
+    });
+
+    testWidgets('verifies icon sizes and dimensions across scale sizes', (
+      WidgetTester tester,
+    ) async {
+      final specs = [
+        (IconButtonSize.xSmall, 32.0, 20.0),
+        (IconButtonSize.small, 40.0, 24.0),
+        (IconButtonSize.medium, 56.0, 24.0),
+        (IconButtonSize.large, 72.0, 30.86),
+        (IconButtonSize.xLarge, 96.0, 32.0),
+        (IconButtonSize.twoXLarge, 136.0, 40.0),
+      ];
+
+      for (final spec in specs) {
+        final sizeEnum = spec.$1;
+        final expectedDim = spec.$2;
+        final expectedIconSize = spec.$3;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Center(
+                child: MechanixIconButton(
+                  size: sizeEnum,
+                  icon: Icons.star,
+                  onPressed: () {},
+                ),
+              ),
+            ),
+          ),
+        );
+
+        final sizedBoxFinder = find
+            .ancestor(
+              of: find.byIcon(Icons.star),
+              matching: find.byType(SizedBox),
+            )
+            .first;
+        final sizedBox = tester.widget<SizedBox>(sizedBoxFinder);
+        expect(sizedBox.width, equals(expectedDim));
+        expect(sizedBox.height, equals(expectedDim));
+
+        final iconWidget = tester.widget<Icon>(find.byIcon(Icons.star));
+        expect(iconWidget.size, equals(expectedIconSize));
+      }
+    });
+
+    testWidgets('enforces minimum 48x48 tap target on xSmall and small sizes', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Column(
+              children: [
+                MechanixIconButton(
+                  size: IconButtonSize.xSmall,
+                  icon: Icons.check,
+                  onPressed: () {},
+                ),
+                MechanixIconButton(
+                  size: IconButtonSize.small,
+                  icon: Icons.close,
+                  onPressed: () {},
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      final checkConstrainedBox = tester.widget<ConstrainedBox>(
+        find
+            .ancestor(
+              of: find.byIcon(Icons.check),
+              matching: find.byType(ConstrainedBox),
+            )
+            .last,
+      );
+      expect(checkConstrainedBox.constraints.minWidth, equals(48.0));
+      expect(checkConstrainedBox.constraints.minHeight, equals(48.0));
+
+      final closeConstrainedBox = tester.widget<ConstrainedBox>(
+        find
+            .ancestor(
+              of: find.byIcon(Icons.close),
+              matching: find.byType(ConstrainedBox),
+            )
+            .last,
+      );
+      expect(closeConstrainedBox.constraints.minWidth, equals(48.0));
+      expect(closeConstrainedBox.constraints.minHeight, equals(48.0));
+    });
+
+    testWidgets('handles tap and long press events when enabled', (
+      WidgetTester tester,
+    ) async {
+      var tapped = false;
+      var longPressed = false;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: MechanixIconButton(
+              icon: Icons.thumb_up,
+              onPressed: () => tapped = true,
+              onLongPress: () => longPressed = true,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byIcon(Icons.thumb_up));
+      expect(tapped, isTrue);
+
+      await tester.longPress(find.byIcon(Icons.thumb_up));
+      expect(longPressed, isTrue);
+    });
+
+    testWidgets('respects disabled state when onPressed is null', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: MechanixIconButton(icon: Icons.block, onPressed: null),
+          ),
+        ),
+      );
+
+      final button = tester.widget<IconButton>(find.byType(IconButton));
+      expect(button.onPressed, isNull);
+    });
+
+    testWidgets('resolves focused border for all variants when focused', (
+      WidgetTester tester,
+    ) async {
+      final focusNode = FocusNode();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: MechanixIconButton.filled(
+              icon: Icons.star,
+              focusNode: focusNode,
+              autofocus: true,
+              onPressed: () {},
+            ),
+          ),
+        ),
+      );
+
+      final iconButton = tester.widget<IconButton>(find.byType(IconButton));
+      final side = iconButton.style?.side?.resolve({WidgetState.focused});
+      expect(side, isNotNull);
+      expect(side?.width, equals(3.0));
+    });
+
+    testWidgets('standard icon button has no border by default and 3px border only when focused', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: MechanixIconButton.standard(
+              icon: Icons.star,
+              onPressed: () {},
+            ),
+          ),
+        ),
+      );
+
+      final iconButton = tester.widget<IconButton>(find.byType(IconButton));
+      final defaultSide = iconButton.style?.side?.resolve({});
+      final focusedSide = iconButton.style?.side?.resolve({WidgetState.focused});
+
+      expect(defaultSide, isNull);
+      expect(focusedSide, isNotNull);
+      expect(focusedSide?.width, equals(3.0));
+    });
+
+    testWidgets('verifies 48x48 min tap target for xSmall icon button', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: MechanixIconButton(
+              size: IconButtonSize.xSmall, // 32x32 visual
+              icon: Icons.check,
+              onPressed: () {},
+            ),
+          ),
+        ),
+      );
+
+      // Find the outer ConstrainedBox wrapping the MechanixIconButton
+      final constrainedBox = tester.widget<ConstrainedBox>(
+        find
+            .ancestor(
+              of: find.byIcon(Icons.check),
+              matching: find.byType(ConstrainedBox),
+            )
+            .last,
+      );
+
+      // Verify the tap target constraints are at least 48x48
+      expect(constrainedBox.constraints.minWidth, equals(48.0));
+      expect(constrainedBox.constraints.minHeight, equals(48.0));
+    });
+
+    testWidgets('verifies 48x48 min tap target for small icon button', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: MechanixIconButton(
+              size: IconButtonSize.small, // 40X40 visual
+              icon: Icons.check,
+              onPressed: () {},
+            ),
+          ),
+        ),
+      );
+
+      // Find the outer ConstrainedBox wrapping the button
+      final constrainedBox = tester.widget<ConstrainedBox>(
+        find
+            .ancestor(
+              of: find.byIcon(Icons.check),
+              matching: find.byType(ConstrainedBox),
+            )
+            .last,
+      );
+
+      // Verify the tap target constraints are at least 48x48
+      expect(constrainedBox.constraints.minWidth, equals(48.0));
+      expect(constrainedBox.constraints.minHeight, equals(48.0));
+    });
+  });
+}

--- a/widgets/test/theme/theme_test.dart
+++ b/widgets/test/theme/theme_test.dart
@@ -60,6 +60,13 @@ void main() {
       expect(textTheme.titleMedium?.color, equals(theme.colorScheme.onSurface));
     });
 
+    test('MechanixTheme.createTheme creates theme with iconButtonTheme and IconButtonThemeDataConfig extension', () {
+      final theme = MechanixTheme.light;
+
+      expect(theme.iconButtonTheme, isNotNull);
+      expect(theme.extension<IconButtonThemeDataConfig>(), isNotNull);
+    });
+
     test('MechanixTheme.createTheme creates theme from custom colorScheme', () {
       const customColorScheme = ColorScheme.light(
         primary: Colors.indigo,


### PR DESCRIPTION
#### Summary

Added the **Icon Buttons** component to the Mechanix Widgets design system with support for multiple sizes, variants, shapes, interactive states, and touch-target requirements.

#### Changes

* Added icon button sizing scale:

  * Extra Small — `32 × 32`
  * Small — `40 × 40`
  * Medium — `56 × 56`
  * Large — `72 × 72`
  * Extra Large — `96 × 96`
  * 2X Large — `136 × 136`
* Defined corresponding icon sizes from `20px` to `40px`.
* Maintained a minimum **48 × 48 touch target** for Extra Small and Small buttons.
* Added supported variants:

  * Filled
  * Tonal
  * Outline
  * Standard
* Added shape options:

  * Square
  * Rounded
* Added interactive states:

  * Enabled
  * Hovered
  * Pressed
  * Focused
  * Disabled
* Added state-aware styling using `WidgetStateProperty` for:

  * Background color
  * Foreground/icon color
  * Border side
* Added theme configuration through `IconButtonThemeDataConfig`.


----

<img width="1272" height="759" alt="image" src="https://github.com/user-attachments/assets/1c211ae5-92d9-4be6-a398-07d7b80206b8" />

<img width="1313" height="756" alt="image" src="https://github.com/user-attachments/assets/165c1253-fb3f-4fdb-b925-ff915ccb86f9" />

